### PR TITLE
add kv cache offloading example

### DIFF
--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -5,23 +5,28 @@ from tensorrt_llm.llmapi import KvCacheConfig
 def main():
 
     prompt_a = (
-        "Given the following question and four candidate answers (A, B, C and D), choose the best answer.\n"
+        "Given the following question and four candidate answers (A, B, C and D), choose the best answer."
         "The following excerpt is from a pamphlet.\nYou will do me the justice to remember, "
         "that I have always strenuously supported the Right of every man to his own opinion"
     )
 
     prompt_b = (
-        "Question: This question refers to the following information.\nRead the following excerpt."
-        "\nThe revolutionary seed had penetrated into every country and spread more or less. "
+        "Question: This question refers to the following information. Read the following excerpt."
+        "The revolutionary seed had penetrated into every country and spread more or less. "
         "It was greatly developed under")
+
+    kv_cache_max_tokens = 256
+    kv_cache_page_size = 16
+    kv_cache_host_size_in_bytes = 1024**3
 
     # Offloading Off
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=1,
               max_seq_len=256,
-              kv_cache_config=KvCacheConfig(enable_block_reuse=True,
-                                            max_tokens=256,
-                                            tokens_per_block=16))
+              kv_cache_config=KvCacheConfig(
+                  enable_block_reuse=True,
+                  max_tokens=kv_cache_max_tokens,
+                  tokens_per_block=kv_cache_page_size))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(output_a.prompt)
@@ -46,10 +51,11 @@ def main():
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=1,
               max_seq_len=256,
-              kv_cache_config=KvCacheConfig(enable_block_reuse=True,
-                                            max_tokens=256,
-                                            tokens_per_block=16,
-                                            host_cache_size=1024**3))
+              kv_cache_config=KvCacheConfig(
+                  enable_block_reuse=True,
+                  max_tokens=kv_cache_max_tokens,
+                  tokens_per_block=kv_cache_page_size,
+                  host_cache_size=kv_cache_host_size_in_bytes))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(output_a.prompt)

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -16,6 +16,7 @@ def main():
         # "The revolutionary seed had penetrated into every country and spread more or less. "
     )
 
+    kv_cache_free_gpu_memory_fraction = 0.001
     kv_cache_page_size = 16
     kv_cache_host_size_in_bytes = 1024**3
 
@@ -26,7 +27,7 @@ def main():
               max_seq_len=256,
               kv_cache_config=KvCacheConfig(
                   enable_block_reuse=True,
-                  free_gpu_memory_fraction=0.01,
+                  free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
                   tokens_per_block=kv_cache_page_size))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
@@ -64,7 +65,7 @@ def main():
               max_seq_len=256,
               kv_cache_config=KvCacheConfig(
                   enable_block_reuse=True,
-                  free_gpu_memory_fraction=0.01,
+                  free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
                   tokens_per_block=kv_cache_page_size,
                   host_cache_size=kv_cache_host_size_in_bytes))
     # prompt_a occupies kv cache pool

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -6,20 +6,20 @@ def main():
 
     prompt_a = (
         "Given the following question and four candidate answers (A, B, C and D), choose the best answer."
-        "The following excerpt is from a pamphlet.\nYou will do me the justice to remember, "
-        "that I have always strenuously supported the Right of every man to his own opinion"
+        "The following excerpt is from a pamphlet. You will do me the justice to remember, "
     )
 
     prompt_b = (
         "Question: This question refers to the following information. Read the following excerpt."
         "The revolutionary seed had penetrated into every country and spread more or less. "
-        "It was greatly developed under")
+    )
 
     kv_cache_max_tokens = 256
     kv_cache_page_size = 16
     kv_cache_host_size_in_bytes = 1024**3
 
     # Offloading Off
+    print("\n === Offloading Off === \n")
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=1,
               max_seq_len=256,
@@ -48,6 +48,7 @@ def main():
     llm.shutdown()
 
     # Offloading On
+    print("\n === Offloading On === \n")
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=1,
               max_seq_len=256,

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -8,13 +8,15 @@ def main():
 
     prompt_a = (
         "Given the following question and four candidate answers (A, B, C and D), choose the best answer."
-        # "The following excerpt is from a pamphlet. You will do me the justice to remember, "
+        "The following excerpt is from a pamphlet. You will do me the justice to remember, "
     )
 
     prompt_b = (
         "Question: This question refers to the following information. Read the following excerpt."
-        # "The revolutionary seed had penetrated into every country and spread more or less. "
+        "The revolutionary seed had penetrated into every country and spread more or less. "
     )
+    max_batch_size = 1
+    max_seq_len = 512
 
     kv_cache_free_gpu_memory_fraction = 0.001
     kv_cache_page_size = 16
@@ -23,8 +25,8 @@ def main():
     # Offloading Off
     print("\n ======  Offloading Off ======  \n")
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-              max_batch_size=1,
-              max_seq_len=256,
+              max_batch_size=max_batch_size,
+              max_seq_len=max_seq_len,
               kv_cache_config=KvCacheConfig(
                   enable_block_reuse=True,
                   free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
@@ -61,8 +63,8 @@ def main():
     # Offloading On
     print("\n ======  Offloading On ======  \n")
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-              max_batch_size=1,
-              max_seq_len=256,
+              max_batch_size=max_batch_size,
+              max_seq_len=max_seq_len,
               kv_cache_config=KvCacheConfig(
                   enable_block_reuse=True,
                   free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -1,0 +1,33 @@
+from tensorrt_llm import LLM
+from tensorrt_llm.llmapi import KvCacheConfig
+
+
+def main():
+    print("\n=== KV Cache Configuration Example ===")
+    print("\n1. KV Cache Configuration:")
+
+    llm_advanced = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+                       max_batch_size=1,
+                       max_seq_len=1024,
+                       kv_cache_config=KvCacheConfig(
+                           free_gpu_memory_fraction=0.5,
+                           enable_block_reuse=True,
+                           max_tokens=1024,
+                           host_cache_size=1 * 1024 * 1024 * 1024,
+                           tokens_per_block=32))
+
+    prompts = [
+        "Hello, my name is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    outputs = llm_advanced.generate(prompts)
+    for i, output in enumerate(outputs):
+        print(f"Query {i+1}: {output.prompt}")
+        print(f"Answer: {output.outputs[0].text[:100]}...")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -16,21 +16,20 @@ def main():
         "The revolutionary seed had penetrated into every country and spread more or less. "
     )
     max_batch_size = 1
-    max_seq_len = 512
+    max_seq_len = 256
 
-    kv_cache_free_gpu_memory_fraction = 0.001
+    kv_cache_max_tokens = 256
     kv_cache_page_size = 16
-    kv_cache_host_size_in_bytes = 1024**3
 
     # Offloading Off
     print("\n ======  Offloading Off ======  \n")
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=max_batch_size,
               max_seq_len=max_seq_len,
-              kv_cache_config=KvCacheConfig(
-                  enable_block_reuse=True,
-                  free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
-                  tokens_per_block=kv_cache_page_size))
+              kv_cache_config=KvCacheConfig(enable_block_reuse=True,
+                                            max_tokens=kv_cache_max_tokens,
+                                            tokens_per_block=kv_cache_page_size,
+                                            host_cache_size=0))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(
@@ -65,11 +64,10 @@ def main():
     llm = LLM(model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
               max_batch_size=max_batch_size,
               max_seq_len=max_seq_len,
-              kv_cache_config=KvCacheConfig(
-                  enable_block_reuse=True,
-                  free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
-                  tokens_per_block=kv_cache_page_size,
-                  host_cache_size=kv_cache_host_size_in_bytes))
+              kv_cache_config=KvCacheConfig(enable_block_reuse=True,
+                                            max_tokens=kv_cache_max_tokens,
+                                            tokens_per_block=kv_cache_page_size,
+                                            host_cache_size=1024**3))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -36,7 +36,7 @@ def main():
     # since max_batch_size=1, prompt_b clears and update kv cache
     output_b = llm.generate(prompt_b)
     print(
-        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_b.outputs[0].text!r}"
     )
 
     # prompt_a clears and update kv cache again
@@ -50,7 +50,7 @@ def main():
     # no kv cache reuse happens
     output_b = llm.generate(prompt_b)
     print(
-        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_b.outputs[0].text!r}"
     )
 
     llm.shutdown()
@@ -75,7 +75,7 @@ def main():
     # kv cache of prompt_b keeps in device memory.
     output_b = llm.generate(prompt_b)
     print(
-        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_b.outputs[0].text!r}"
     )
 
     # kv cache of prompt_a will be onboarded to device memory, kv cache of prompt_b will be offloaded to host memory.
@@ -89,7 +89,7 @@ def main():
     # kv cache of prompt_b will be reused.
     output_b = llm.generate(prompt_b)
     print(
-        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_b.outputs[0].text!r}"
     )
 
     llm.shutdown()

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -29,21 +29,29 @@ def main():
                   tokens_per_block=kv_cache_page_size))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
-    print(output_a.prompt)
+    print(
+        f"Prompt: {output_a.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # since max_batch_size=1, prompt_b clears and update kv cache
     output_b = llm.generate(prompt_b)
-    print(output_b.prompt)
+    print(
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # prompt_a clears and update kv cache again
     # no kv cache reuse happens
     output_a = llm.generate(prompt_a)
-    print(output_a.prompt)
+    print(
+        f"Prompt: {output_a.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # prompt_b clears and update kv cache again
     # no kv cache reuse happens
     output_b = llm.generate(prompt_b)
-    print(output_b.prompt)
+    print(
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     llm.shutdown()
 
@@ -59,22 +67,30 @@ def main():
                   host_cache_size=kv_cache_host_size_in_bytes))
     # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
-    print(output_a.prompt)
+    print(
+        f"Prompt: {output_a.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # since max_batch_size=1, and offloading is enabled, kv cache of prompt_a will be offloaded to host memory.
     # kv cache of prompt_b keeps in device memory.
     output_b = llm.generate(prompt_b)
-    print(output_b.prompt)
+    print(
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # kv cache of prompt_a will be onboarded to device memory, kv cache of prompt_b will be offloaded to host memory.
     # kv cache of prompt_a will be reused.
     output_a = llm.generate(prompt_a)
-    print(output_a.prompt)
+    print(
+        f"Prompt: {output_a.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     # kv cache of prompt_b will be onboarded to device memory, kv cache of prompt_a will be offloaded to host memory.
     # kv cache of prompt_b will be reused.
     output_b = llm.generate(prompt_b)
-    print(output_b.prompt)
+    print(
+        f"Prompt: {output_b.prompt!r}, Generated text: {output_a.outputs[0].text!r}"
+    )
 
     llm.shutdown()
 

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -22,7 +22,7 @@ def main():
               kv_cache_config=KvCacheConfig(enable_block_reuse=True,
                                             max_tokens=256,
                                             tokens_per_block=16))
-    # prompt_a occupies kv cache
+    # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(output_a.prompt)
 
@@ -31,10 +31,12 @@ def main():
     print(output_b.prompt)
 
     # prompt_a clears and update kv cache again
+    # no kv cache reuse happens
     output_a = llm.generate(prompt_a)
     print(output_a.prompt)
 
     # prompt_b clears and update kv cache again
+    # no kv cache reuse happens
     output_b = llm.generate(prompt_b)
     print(output_b.prompt)
 
@@ -48,7 +50,7 @@ def main():
                                             max_tokens=256,
                                             tokens_per_block=16,
                                             host_cache_size=1024**3))
-    # prompt_a occupies kv cache
+    # prompt_a occupies kv cache pool
     output_a = llm.generate(prompt_a)
     print(output_a.prompt)
 

--- a/examples/llm-api/llm_kv_cache_offloading.py
+++ b/examples/llm-api/llm_kv_cache_offloading.py
@@ -6,12 +6,12 @@ def main():
 
     prompt_a = (
         "Given the following question and four candidate answers (A, B, C and D), choose the best answer."
-        "The following excerpt is from a pamphlet. You will do me the justice to remember, "
+        # "The following excerpt is from a pamphlet. You will do me the justice to remember, "
     )
 
     prompt_b = (
         "Question: This question refers to the following information. Read the following excerpt."
-        "The revolutionary seed had penetrated into every country and spread more or less. "
+        # "The revolutionary seed had penetrated into every country and spread more or less. "
     )
 
     kv_cache_max_tokens = 256


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot [-h] ['run', 'kill', 'skip', 'reuse-pipeline'] ...`

Provide a user friendly way for developers to interact with a Jenkins server.

Run `/bot [-h|--help]` to print this help message.

See details below for each supported subcommand.

<details>

`run  [--reuse-test (optional)pipeline-id --disable-fail-fast --skip-test --stage-list "A10-PyTorch-1, xxx" --gpu-type "A30, H100_PCIe" --test-backend "pytorch, cpp" --add-multi-gpu-test --only-multi-gpu-test --disable-multi-gpu-test --post-merge --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx" --detailed-log --debug(experimental)]`

Launch build/test pipelines. All previously running jobs will be killed.

`--reuse-test (optional)pipeline-id ` *(OPTIONAL)* : Allow the new pipeline to reuse build artifacts and skip successful test stages from a specified pipeline or the last pipeline if no pipeline-id is indicated. If the Git commit ID has changed, this option will be always ignored. The DEFAULT behavior of the bot is to reuse build artifacts and successful test results from the last pipeline.

`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.

`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.

`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.

`--stage-list "A10-PyTorch-1, xxx"` *(OPTIONAL)* : Only run the specified test stages. Examples: "A10-PyTorch-1, xxx". Note: Does **NOT** update GitHub check status.

`--gpu-type "A30, H100_PCIe"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: "A30, H100_PCIe". Note: Does **NOT** update GitHub check status.

`--test-backend "pytorch, cpp"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: "pytorch, cpp" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.

`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.

`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.

`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.

`--extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage "H100_PCIe-TensorRT-Post-Merge-1, xxx".

`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.

`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.

For guidance on mapping tests to stage names, see `docs/source/reference/ci-overview.md`
and the `scripts/test_to_stage_mapping.py` helper.

### kill

`kill  `

Kill all running builds associated with pull request.

### skip

`skip --comment COMMENT `

Skip testing for latest commit on pull request. `--comment "Reason for skipping build/test"` is required. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

### reuse-pipeline

`reuse-pipeline `

Reuse a previous pipeline to validate current commit. This action will also kill all currently running builds associated with the pull request. IMPORTANT NOTE: This is dangerous since lack of user care and validation can cause top of tree to break.

</details>
